### PR TITLE
Fix workflow schedule

### DIFF
--- a/.github/workflows/sync_leetcode.yml
+++ b/.github/workflows/sync_leetcode.yml
@@ -3,7 +3,7 @@ name: Sync LeetCode Solutions
 on:
   workflow_dispatch:        # Manual trigger
   schedule:
-    - cron: "*/5 * * * *"   # Every 5 minutes
+    - cron: "0 3 * * *"   # Daily at 3 AM
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## Summary
- run the `sync_leetcode` workflow daily instead of every 5 minutes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686eb0050fb4832b977b4959607566c2