### PR TITLE
Add fail-fast flags in sync workflows

### DIFF
--- a/.github/workflows/manual_leetcode_sync.yml
+++ b/.github/workflows/manual_leetcode_sync.yml
@@ -30,6 +30,7 @@ jobs:
 
       - name: Fetch Accepted Solutions and Organize
         run: |
+          set -euo pipefail
           mkdir -p solutions
 
           echo "Fetching all accepted problems..."

--- a/.github/workflows/sync_leetcode.yml
+++ b/.github/workflows/sync_leetcode.yml
@@ -35,6 +35,7 @@ jobs:
 
       - name: Fetch Accepted Solutions and Organize
         run: |
+          set -euo pipefail
           mkdir -p solutions
 
           leetcode show --all --format=json > all_solutions.json


### PR DESCRIPTION
## Summary
- ensure the sync steps fail fast by adding `set -euo pipefail`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686eb0087008832b950be6b7451b7c45